### PR TITLE
[FEAT] dotenv 추가, Develop/frontend -> master

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# .env 파일 예시
+
+PAPAGO_ID=###
+PAPAGO_SECRET=###

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ __pycache__/
 wandb/
 experiment/
 notebooks/
+
+# 환경 변수 설정 파일
+.env

--- a/app/models/translation.py
+++ b/app/models/translation.py
@@ -1,9 +1,13 @@
 # translation
 import requests
+from dotenv import load_dotenv
+import os
+
+load_dotenv(verbose=True)
 
 def get_translate(text):
-    client_id = "######" # <-- client_id 기입
-    client_secret = "#######" # <-- client_secret 기입
+    client_id = os.getenv('PAPAGO_ID')
+    client_secret = os.getenv('PAPAGO_SECRET')
 
     data = {'text' : text,
             'source' : 'ko',

--- a/poetry.lock
+++ b/poetry.lock
@@ -1136,6 +1136,21 @@ files = [
 six = ">=1.5"
 
 [[package]]
+name = "python-dotenv"
+version = "0.21.0"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "python-dotenv-0.21.0.tar.gz", hash = "sha256:b77d08274639e3d34145dfa6c7008e66df0f04b7be7a75fd0d5292c191d79045"},
+    {file = "python_dotenv-0.21.0-py3-none-any.whl", hash = "sha256:1684eb44636dd462b66c3ee016599815514527ad99965de77f43e0944634a7e5"},
+]
+
+[package.extras]
+cli = ["click (>=5.0)"]
+
+[[package]]
 name = "python-multipart"
 version = "0.0.5"
 description = "A streaming multipart parser for Python"
@@ -2026,4 +2041,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7,<3.9.7"
-content-hash = "a305fff833dc2cca51c8d2693a6d32179675dc47bb21224c09db31cbf92846ca"
+content-hash = "cf0cf2e888d81770d935106e6dd8ccc13a93a67af94ad670bec76226f72e50b5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ gunicorn = "^20.1.0"
 streamlit = "^1.16.0"
 opencv-python-headless = "4.5.1.48"
 streamlit-drawable-canvas = "^0.9.2"
+python-dotenv = "^0.21.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"


### PR DESCRIPTION
## Overview

- API KEY 같이 민감한 값을 `.env` 파일로 설정할 수 있도록 하는 기능
<br>

## Change Log

- `.env` 파일을 불러오는 `python-dotenv` 패키지 추가
- `.env` 파일 예시인 `.env.example` 추가

<br>

## To Reviewer

- `.env.example` 파일 참고해서 `.env` 파일 만들고, 파파고 번역 잘 되는지 확인하면 될 것 같아

<br>

## Issue Tag
boostcampaitech4lv23cv2/final-project-level2-cv-11#17

<br>